### PR TITLE
Import cleanup

### DIFF
--- a/src/PARA_ATM/Application/LaunchApp.py
+++ b/src/PARA_ATM/Application/LaunchApp.py
@@ -9,8 +9,11 @@ Run this module to invoke the application. It contains the main features and fun
 """
 
 import os
-import sys
 from pathlib import Path
+
+import psycopg2
+import pandas as pd
+import numpy as np
 
 import bokeh as bk
 import bokeh.layouts as bklayouts
@@ -20,14 +23,9 @@ from bokeh.models import ColumnDataSource
 from bokeh.tile_providers import Vendors, get_provider
 from bokeh.server.server import Server
 
-#Question: Is this the best way to assign the pathing? Should we change the directory structure or the location of this application file to avoid this?
-src_dir = str(Path(__file__).parent.parent.parent)
-sys.path.insert(0, src_dir)
-
-from PARA_ATM import *
 from PARA_ATM.Commands import readNATS,readIFF,readTDDS
-from PARA_ATM.Application.plotting_tools import *
-from PARA_ATM.Application.db_tools import *
+from .plotting_tools import merc
+from .db_tools import getTableList
 
 
 # Variables for NATS and Sherlock directories

--- a/src/PARA_ATM/Application/db_tools.py
+++ b/src/PARA_ATM/Application/db_tools.py
@@ -1,8 +1,3 @@
-
-import time
-import math
-import glob
-
 def getTableList(cursor):
 
     #Execute query to fetch flight data

--- a/src/PARA_ATM/Application/plotting_tools.py
+++ b/src/PARA_ATM/Application/plotting_tools.py
@@ -1,7 +1,4 @@
-
-import time
 import math
-import glob
 
 def merc(lats,lons):
     coords_xy = ([],[])

--- a/src/PARA_ATM/Commands/Airport.py
+++ b/src/PARA_ATM/Commands/Airport.py
@@ -10,8 +10,6 @@ Example user command to plot all airports in the US.
 
 '''
 
-from PARA_ATM import *
-
 class Command:
     '''
         Class Command wraps the command methods and functions to be executed. For user-defined commands, this name 

--- a/src/PARA_ATM/Commands/Airport.py
+++ b/src/PARA_ATM/Commands/Airport.py
@@ -1,4 +1,4 @@
-'''
+"""
 
 NASA NextGen NAS ULI Information Fusion
         
@@ -8,13 +8,13 @@ NASA NextGen NAS ULI Information Fusion
 
 Example user command to plot all airports in the US.
 
-'''
+"""
 
 class Command:
-    '''
+    """
         Class Command wraps the command methods and functions to be executed. For user-defined commands, this name 
         should be kept the same (Command).
-    '''
+    """
     
     #Here, the database connector and the parameter are passed as arguments. This can be changed as per need.
     def __init__(self, cursor, airportIATA):

--- a/src/PARA_ATM/Commands/FPF_gen.py
+++ b/src/PARA_ATM/Commands/FPF_gen.py
@@ -1,4 +1,4 @@
-'''
+"""
 
 NASA NextGen NAS ULI Information Fusion
         
@@ -7,7 +7,7 @@ NASA NextGen NAS ULI Information Fusion
 @date: 06/05/2019
 
 call groundSSD in a loop, given input variable distributions
-'''
+"""
 
 import sys
 import os
@@ -115,7 +115,7 @@ def main(infile):
 
 if __name__ == '__main__':
     main(sys.argv[1])
-    '''
+    """
     fig = plt.figure(figsize=(16,9),tight_layout=True)
     look = get_lookahead_list()
     for j,res in enumerate(results):
@@ -133,4 +133,4 @@ if __name__ == '__main__':
             ax.set_title(ac)
         plt.savefig('fpf_%f_nominal.png'%look[j])
         plt.clf()
-    '''
+    """

--- a/src/PARA_ATM/Commands/Helpers/DataStore.py
+++ b/src/PARA_ATM/Commands/Helpers/DataStore.py
@@ -1,6 +1,11 @@
 import psycopg2
 import pandas as pd
-import centaur
+
+try:
+    import centaur
+except ImportError:
+    # Allow centaur to be optional
+    pass
 
 class dbError(Exception):
     def __init__(self):

--- a/src/PARA_ATM/Commands/NATS_GateToGateSim.py
+++ b/src/PARA_ATM/Commands/NATS_GateToGateSim.py
@@ -10,8 +10,10 @@ Command call to interface NATS module with PARA-ATM to fetch generated trajector
 
 '''
 
-from PARA_ATM import *
+import time
+import os
 import imp
+from pathlib import Path
 
 class Command:
     '''

--- a/src/PARA_ATM/Commands/NATS_GateToGateSim.py
+++ b/src/PARA_ATM/Commands/NATS_GateToGateSim.py
@@ -1,4 +1,4 @@
-'''
+"""
 
 NASA NextGen NAS ULI Information Fusion
         
@@ -8,7 +8,7 @@ NASA NextGen NAS ULI Information Fusion
 
 Command call to interface NATS module with PARA-ATM to fetch generated trajectories.
 
-'''
+"""
 
 import time
 import os
@@ -16,10 +16,10 @@ import imp
 from pathlib import Path
 
 class Command:
-    '''
+    """
         Class Command wraps the command methods and functions to be executed. For user-defined commands, this name 
         should be kept the same (Command).
-    '''
+    """
     
     #Here, the database connector and the parameter are passed as arguments. This can be changed as per need.
     def __init__(self, cursor, *args):

--- a/src/PARA_ATM/Commands/PlotGraph.py
+++ b/src/PARA_ATM/Commands/PlotGraph.py
@@ -10,7 +10,9 @@ Command to plot airspeed vs altitude graph for a given callsign as argument.
 
 '''
 
-from PARA_ATM import *
+import matplotlib.pyplot as plt
+
+from PARA_ATM import DataStore
 
 class Command:
     '''

--- a/src/PARA_ATM/Commands/PlotGraph.py
+++ b/src/PARA_ATM/Commands/PlotGraph.py
@@ -1,4 +1,4 @@
-'''
+"""
 
 NASA NextGen NAS ULI Information Fusion
         
@@ -8,17 +8,17 @@ NASA NextGen NAS ULI Information Fusion
 
 Command to plot airspeed vs altitude graph for a given callsign as argument.
 
-'''
+"""
 
 import matplotlib.pyplot as plt
 
 from PARA_ATM import DataStore
 
 class Command:
-    '''
+    """
         Class Command wraps the command methods and functions to be executed. For user-defined commands, this name 
         should be kept the same (Command).
-    '''
+    """
     
     #Here, the database connector and the parameter are passed as arguments. This can be changed as per need.
     def __init__(self, cursor, flightCallsign):

--- a/src/PARA_ATM/Commands/RegressionCurve.py
+++ b/src/PARA_ATM/Commands/RegressionCurve.py
@@ -10,7 +10,10 @@ Command to plot airspeed vs altitude regression curve for a given callsign as ar
 
 '''
 
-from PARA_ATM import *
+import numpy as np
+import matplotlib.pyplot as plt
+
+from PARA_ATM import DataStore
 
 class Command:
     '''

--- a/src/PARA_ATM/Commands/RegressionCurve.py
+++ b/src/PARA_ATM/Commands/RegressionCurve.py
@@ -1,4 +1,4 @@
-'''
+"""
 
 NASA NextGen NAS ULI Information Fusion
         
@@ -8,7 +8,7 @@ NASA NextGen NAS ULI Information Fusion
 
 Command to plot airspeed vs altitude regression curve for a given callsign as argument.
 
-'''
+"""
 
 import numpy as np
 import matplotlib.pyplot as plt
@@ -16,10 +16,10 @@ import matplotlib.pyplot as plt
 from PARA_ATM import DataStore
 
 class Command:
-    '''
+    """
         Class Command wraps the command methods and functions to be executed. For user-defined commands, this name 
         should be kept the same (Command).
-    '''
+    """
     
     #Here, the database connector and the parameter are passed as arguments. This can be changed as per need.
     def __init__(self, cursor, flightCallsign):

--- a/src/PARA_ATM/Commands/Reliability.py
+++ b/src/PARA_ATM/Commands/Reliability.py
@@ -10,7 +10,7 @@ Conduct reliability analysis
 
 '''
 
-from PARA_ATM import *
+
 
 class Command:
     '''

--- a/src/PARA_ATM/Commands/Reliability.py
+++ b/src/PARA_ATM/Commands/Reliability.py
@@ -1,4 +1,4 @@
-'''
+"""
 
 NASA NextGen NAS ULI Information Fusion
         
@@ -8,15 +8,15 @@ NASA NextGen NAS ULI Information Fusion
 
 Conduct reliability analysis
 
-'''
+"""
 
 
 
 class Command:
-    '''
+    """
         Class Command wraps the command methods and functions to be executed. For user-defined commands, this name 
         should be kept the same (Command).
-    '''
+    """
     
     #Here, the database connector and the parameter are passed as arguments. This can be changed as per need.
     def __init__(self, cursor, airportIATA, analysis_type):

--- a/src/PARA_ATM/Commands/groundSSD.py
+++ b/src/PARA_ATM/Commands/groundSSD.py
@@ -1,4 +1,4 @@
-'''
+"""
 
 NASA NextGen NAS ULI Information Fusion
         
@@ -13,7 +13,7 @@ airportIATA - 3 letter airport ID
 separation - the distance threshold for conflict, in meters
 
 SSD calculations from https://github.com/TUDelft-CNS-ATM/bluesky by TU Delft
-'''
+"""
 
 import pandas as pd
 import numpy as np
@@ -28,10 +28,10 @@ nm = 0.868976
 ft_per_m = 0.3048
 
 class Command:
-    '''
+    """
         Class Command wraps the command methods and functions to be executed. For user-defined commands, this name 
         should be kept the same (Command).
-    '''
+    """
     
     #Here, the database connector and the parameter are passed as arguments. This can be changed as per need.
     def __init__(self, args=[]):
@@ -231,7 +231,7 @@ class Command:
         circle_tup,circle_lst = tuple(),[]
         for i in range(len(traffic)):
             
-            '''
+            """
             if ac_info[i]['vmax'] == 30*nm: #taxi
                 heading = traffic.iloc[i]['heading']
                 #put between 0-360
@@ -244,7 +244,7 @@ class Command:
                     xyc[opp_heading_ind-45+j] = xyc[opp_heading_ind-45+j] * (1+j/45)
                 for j in range(45):
                     xyc[opp_heading_ind+j] = xyc[opp_heading_ind+j] * (2-j/45)
-            '''
+            """
 
             circle_tup+=((tuple(map(tuple, np.flipud(xyc * ac_info[i]['vmax']))), tuple(map(tuple , xyc * ac_info[i]['vmin'])),),)
             circle_lst.append([list(map(list, np.flipud(xyc * ac_info[i]['vmax']))), list(map(list , xyc * ac_info[i]['vmin'])),])

--- a/src/PARA_ATM/Commands/groundSSD.py
+++ b/src/PARA_ATM/Commands/groundSSD.py
@@ -15,7 +15,6 @@ separation - the distance threshold for conflict, in meters
 SSD calculations from https://github.com/TUDelft-CNS-ATM/bluesky by TU Delft
 '''
 
-from PARA_ATM import *
 import pandas as pd
 import numpy as np
 import pyclipper

--- a/src/PARA_ATM/Commands/readIFF.py
+++ b/src/PARA_ATM/Commands/readIFF.py
@@ -7,10 +7,12 @@ NASA NextGen NAS ULI Information Fusion
 Visualize IFF file
 '''
 
-from PARA_ATM import *
+import numpy as np
+import pandas as pd
 from multiprocessing import Lock, Process, Queue
 from sqlalchemy import create_engine
-import pandas as pd
+
+from PARA_ATM import DataStore
 
 def value_change(x):
     try:

--- a/src/PARA_ATM/Commands/readIFF.py
+++ b/src/PARA_ATM/Commands/readIFF.py
@@ -1,11 +1,11 @@
-'''
+"""
 NASA NextGen NAS ULI Information Fusion
         
 @organization: Southwest Research Institute
 @author: Michael Hartnett
 @date: 04/16/2019
 Visualize IFF file
-'''
+"""
 
 import numpy as np
 import pandas as pd
@@ -21,10 +21,10 @@ def value_change(x):
         return -100.
 
 class Command:
-    '''
+    """
         args:
             filename = name of the NATS simulation output csv
-    '''
+    """
     
     #Here, the database connector and the parameter are passed as arguments. This can be changed as per need.
     def __init__(self, filename, **kwargs):

--- a/src/PARA_ATM/Commands/readNATS.py
+++ b/src/PARA_ATM/Commands/readNATS.py
@@ -1,4 +1,4 @@
-'''
+"""
 
 NASA NextGen NAS ULI Information Fusion
         
@@ -8,7 +8,7 @@ NASA NextGen NAS ULI Information Fusion
 
 Visualize NATS output CSV file
 
-'''
+"""
 
 from pathlib import Path
 import pandas as pd
@@ -20,10 +20,10 @@ from PARA_ATM import DataStore
 
 
 class Command:
-    '''
+    """
         args:
             filename = name of the NATS simulation output csv
-    '''
+    """
     
     #Here, the database connector and the parameter are passed as arguments. This can be changed as per need.
     def __init__(self, filename, **kwargs):

--- a/src/PARA_ATM/Commands/readNATS.py
+++ b/src/PARA_ATM/Commands/readNATS.py
@@ -10,8 +10,14 @@ Visualize NATS output CSV file
 
 '''
 
-from PARA_ATM import *
+from pathlib import Path
+import pandas as pd
+import numpy as np
+
 from sqlalchemy import create_engine
+
+from PARA_ATM import DataStore
+
 
 class Command:
     '''

--- a/src/PARA_ATM/Commands/readTDDS.py
+++ b/src/PARA_ATM/Commands/readTDDS.py
@@ -10,7 +10,6 @@ Pull ASDE-X and SMES data for visualization at given airport
 
 '''
 
-from PARA_ATM import *
 import pandas as pd
 
 class Command:

--- a/src/PARA_ATM/Commands/readTDDS.py
+++ b/src/PARA_ATM/Commands/readTDDS.py
@@ -1,4 +1,4 @@
-'''
+"""
 
 NASA NextGen NAS ULI Information Fusion
         
@@ -8,7 +8,7 @@ NASA NextGen NAS ULI Information Fusion
 
 Pull ASDE-X and SMES data for visualization at given airport
 
-'''
+"""
 
 import pandas as pd
 

--- a/src/PARA_ATM/Commands/reliabilityAnalysis.py
+++ b/src/PARA_ATM/Commands/reliabilityAnalysis.py
@@ -10,11 +10,14 @@ Command call to interface NATS module with PARA-ATM to fetch generated trajector
 
 '''
 
-from PARA_ATM.Commands import runNATS,readNATS
-import PARA_ATM
-from PARA_ATM.Commands.Helpers import DataStore
 import numpy as np
+
+from PARA_ATM.Commands import runNATS,readNATS
+import PARA_ATM.Commands
+from PARA_ATM import DataStore
+
 import centaur
+
 centaur.CentaurUtils.initialize_centaur()
 
 class Command:

--- a/src/PARA_ATM/Commands/reliabilityAnalysis.py
+++ b/src/PARA_ATM/Commands/reliabilityAnalysis.py
@@ -1,4 +1,4 @@
-'''
+"""
 
 NASA NextGen NAS ULI Information Fusion
         
@@ -8,7 +8,7 @@ NASA NextGen NAS ULI Information Fusion
 
 Command call to interface NATS module with PARA-ATM to fetch generated trajectories.
 
-'''
+"""
 
 import numpy as np
 
@@ -21,10 +21,10 @@ import centaur
 centaur.CentaurUtils.initialize_centaur()
 
 class Command:
-    '''
+    """
         Class Command wraps the command methods and functions to be executed. For user-defined commands, this name 
         should be kept the same (Command).
-    '''
+    """
     
     def __init__(self,safety_module):
         """

--- a/src/PARA_ATM/Commands/runNATS.py
+++ b/src/PARA_ATM/Commands/runNATS.py
@@ -1,4 +1,4 @@
-'''
+"""
 
 NASA NextGen NAS ULI Information Fusion
         
@@ -8,17 +8,17 @@ NASA NextGen NAS ULI Information Fusion
 
 Command call to interface NATS module with PARA-ATM to fetch generated trajectories.
 
-'''
+"""
 
 import os
 import imp
 from pathlib import Path
 
 class Command:
-    '''
+    """
         Class Command wraps the command methods and functions to be executed. For user-defined commands, this name 
         should be kept the same (Command).
-    '''
+    """
     
     def __init__(self, params):
         """

--- a/src/PARA_ATM/Commands/runNATS.py
+++ b/src/PARA_ATM/Commands/runNATS.py
@@ -9,9 +9,10 @@ NASA NextGen NAS ULI Information Fusion
 Command call to interface NATS module with PARA-ATM to fetch generated trajectories.
 
 '''
-from PARA_ATM import *
-from PARA_ATM.Commands import readNATS
+
+import os
 import imp
+from pathlib import Path
 
 class Command:
     '''

--- a/src/PARA_ATM/Commands/uli_pyre_gp.py
+++ b/src/PARA_ATM/Commands/uli_pyre_gp.py
@@ -7,14 +7,14 @@ import numpy as np
 class ReliabilityAnalysis:
 
     def __init__(self,capacity,demand):
-        ''' Set demand and capacity values for the airport
+        """ Set demand and capacity values for the airport
             Probabilities are from the pie chart showing the %age of time that the 
                 airport is in each weather condition
             Values are taken from the tables that show the capacity of the airport
                 under the various weather conditions
             Data from: https://www.faa.gov/airports/planning_capacity/profiles/media/SEA-Airport-Capacity-Profile-2018.pdf
             Envision this being replaced by a call to some database in the future
-        '''
+        """
         self.capacity_probs = capacity[0]
         self.capacity_vals = capacity[1]
         self.demand_mean = demand[0]
@@ -26,13 +26,13 @@ class ReliabilityAnalysis:
     # Define response function
     # This is a simple demand-capacity computation
     def func(self,Demand,Dummy):
-        ''' Simple demand-capacity computation
+        """ Simple demand-capacity computation
             args:
                  Demand = the demand distribution
                  Dummy  = dummy variables
             returns:
                  PyRe input vector same length as Demand
-        '''
+        """
 
         n = np.size(Demand)
         # Create samples of Capacity
@@ -48,12 +48,12 @@ class ReliabilityAnalysis:
     # Construct GP for response function
     # Sample the input space
     def construct_GP(self,nsam):
-        ''' Construct GP for response function
+        """ Construct GP for response function
             args:
                  nsam = number of samples
             returns:
                  void, sets self.m to the new GP model
-        '''
+        """
 
         C = np.random.choice(self.capacity_vals,p=self.capacity_probs,size=(nsam,1))
         D = np.random.uniform(self.demand_mean-3*self.demand_stdv,self.demand_mean+3*self.demand_stdv,(nsam,1))
@@ -66,12 +66,12 @@ class ReliabilityAnalysis:
         
     
     def get_stochastic_model(self):
-        ''' Create random variables and define distributions
+        """ Create random variables and define distributions
             args:
                  none
             returns:
                  void, sets self.stochastic_model to the new variable object
-        '''
+        """
 
         self.stochastic_model = pyre.StochasticModel()
              
@@ -85,19 +85,19 @@ class ReliabilityAnalysis:
     
 
     def define_limit_state(self,function=self.func):
-        ''' Define reliability problem
+        """ Define reliability problem
             args:
                  function = option to pass arbitrary limit state function
                             defaults to the one defined above
             returns:
                 void, sets self.limit_state to the new limit state
-        '''
+        """
 
         # Compute P[Demand > Capacity] or P[Demand-Capacity > 0]
         self.limit_state = pyre.LimitState(function)
     
     def analyze(self,nsam,custom_limit_state=None,analysis_type='MC'):
-        ''' Main entry point of the object
+        """ Main entry point of the object
             args:
                 nsam = number of samples for Gaussian process model
                 custom_limit_state = arbitrary limit state function
@@ -106,7 +106,7 @@ class ReliabilityAnalysis:
                                 defaults to monte carlo
             returns:
                 analysis object
-        '''
+        """
 
         construct_GP(nsam)
         get_stochastic_model()

--- a/src/PARA_ATM/Commands/uncertaintyProp.py
+++ b/src/PARA_ATM/Commands/uncertaintyProp.py
@@ -10,11 +10,14 @@ Command call to interface NATS module with PARA-ATM to fetch generated trajector
 
 '''
 
-import PARA_ATM
-from PARA_ATM.Commands import runNATS,readNATS
-from PARA_ATM.Commands.Helpers import DataStore
 import numpy as np
+
+import PARA_ATM.Commands
+from PARA_ATM.Commands import runNATS,readNATS
+from PARA_ATM import DataStore
+
 import centaur
+
 centaur.CentaurUtils.initialize_centaur()
 
 class Command:

--- a/src/PARA_ATM/Commands/uncertaintyProp.py
+++ b/src/PARA_ATM/Commands/uncertaintyProp.py
@@ -1,4 +1,4 @@
-'''
+"""
 
 NASA NextGen NAS ULI Information Fusion
         
@@ -8,7 +8,7 @@ NASA NextGen NAS ULI Information Fusion
 
 Command call to interface NATS module with PARA-ATM to fetch generated trajectories.
 
-'''
+"""
 
 import numpy as np
 
@@ -21,10 +21,10 @@ import centaur
 centaur.CentaurUtils.initialize_centaur()
 
 class Command:
-    '''
+    """
         Class Command wraps the command methods and functions to be executed. For user-defined commands, this name 
         should be kept the same (Command).
-    '''
+    """
     
     def __init__(self,safety_module):
         """

--- a/src/PARA_ATM/Map/MapView.py
+++ b/src/PARA_ATM/Map/MapView.py
@@ -15,7 +15,7 @@ MapView wraps the map to be displayed on the application UI.
     embedded according to user request.
 '''
 
-from PARA_ATM import *
+import numpy as np
 
 def buildMap(flightSelected, dateRangeSelected, filterToggles, cursor, commandParameters):
 

--- a/src/PARA_ATM/Map/MapView.py
+++ b/src/PARA_ATM/Map/MapView.py
@@ -1,4 +1,4 @@
-'''
+"""
 
 NASA NextGen NAS ULI Information Fusion
         
@@ -8,12 +8,12 @@ NASA NextGen NAS ULI Information Fusion
 
 MapView wraps the map to be displayed on the application UI.
 
-'''
+"""
 
-'''
+"""
     buildMap() returns the map to be rendered onto the application layout, with all the map features and functions 
     embedded according to user request.
-'''
+"""
 
 import numpy as np
 

--- a/src/PARA_ATM/Ontology/QueryOntology.py
+++ b/src/PARA_ATM/Ontology/QueryOntology.py
@@ -10,7 +10,8 @@ Command to run a query against an example query against an ontology and return r
 
 '''
 
-from PARA_ATM import *
+from pathlib import Path
+import rdflib
 
 '''
     query() runs the query based on the queryInput from the user's command call.

--- a/src/PARA_ATM/Ontology/QueryOntology.py
+++ b/src/PARA_ATM/Ontology/QueryOntology.py
@@ -1,4 +1,4 @@
-'''
+"""
 
 NASA NextGen NAS ULI Information Fusion
         
@@ -8,14 +8,14 @@ NASA NextGen NAS ULI Information Fusion
 
 Command to run a query against an example query against an ontology and return results. 
 
-'''
+"""
 
 from pathlib import Path
 import rdflib
 
-'''
+"""
     query() runs the query based on the queryInput from the user's command call.
-'''
+"""
 def query(queryInput = ""):
     
     #Instantiate the RDF Graph

--- a/src/PARA_ATM/__init__.py
+++ b/src/PARA_ATM/__init__.py
@@ -1,4 +1,4 @@
-'''
+"""
 
 NASA NextGen NAS ULI Information Fusion
         
@@ -6,41 +6,20 @@ NASA NextGen NAS ULI Information Fusion
 @author: Hari Iyer
 @date: 01/19/2018
 
-This module imports libraries and resources used in the system. The documentation on GitHub has instructions on setting these up locally.
-
-'''
-
-#------------------------Built-in System Modules------------------------#
-
-import os
-import re
-import sys
-import datetime
-import urllib
-import csv
-import imp
-import json
-import importlib
-import math
-import glob
-import time
-import socket
-import pandas as pd
-from pathlib import Path
-import xml.etree.ElementTree as ET
-from ast import literal_eval
-
-#------------------------Installed Third-Party Libraries------------------------#
-
-import matplotlib.pyplot as plt
-import numpy as np
-import psycopg2
-import rdflib
-
-#------------------------Application Modules------------------------#
+"""
 
 from PARA_ATM.Commands.Helpers import DataStore
-from PARA_ATM.Commands import  Airport,NATS_GateToGateSim,PlotGraph,readTDDS,groundSSD,enrouteSSD,readNATS,readIFF,Reliability
+from PARA_ATM.Commands import (
+    Airport,
+    NATS_GateToGateSim,
+    PlotGraph,
+    readTDDS,
+    groundSSD,
+    enrouteSSD,
+    readNATS,
+    readIFF,
+    Reliability
+)
 from PARA_ATM.Map import MapView
 from PARA_ATM.Ontology import QueryOntology
 


### PR DESCRIPTION
Various cleanup of import statements.  Removing `import *` and removing all third-party imports from `__init__.py`.  Other minor changes to allow PARA_ATM to still run if centaur is not installed, and to use `"""` instead of `'''` for docstrings.

Michael, it may be good for you to test this out for some of the different commands.  Because I removed `from PARA_ATM import *` (and I removed the thrid-party libraries from the `PARA_ATM/__init__.py`), other modules that use third-party libraries such as numpy or pandas need to explicitly import them.  I have tried to add these imports back in, but it's possible I missed something, and I only tested readNATS.py.