### PR TITLE
Fix data.to_sql error and add tableExists function

### DIFF
--- a/src/PARA_ATM/Application/LaunchApp.py
+++ b/src/PARA_ATM/Application/LaunchApp.py
@@ -26,7 +26,7 @@ from bokeh.server.server import Server
 from PARA_ATM.Commands.Helpers.DataStore import Access
 from PARA_ATM.Commands import readNATS,readIFF,readTDDS
 from .plotting_tools import merc
-from .db_tools import getTableList,checkTable
+from .db_tools import getTableList,checkForTable
 
 
 # Variables for NATS and Sherlock directories

--- a/src/PARA_ATM/Commands/Helpers/DataStore.py
+++ b/src/PARA_ATM/Commands/Helpers/DataStore.py
@@ -29,13 +29,16 @@ class Access:
         self.cursor.execute("SELECT * FROM flight_data WHERE callsign = %s", ("" + callsign,))
         results = self.cursor.fetchall()
         return results
+
+    def tableExists(self, table_name):
+        """Check whether a table exists in the database"""
+        self.cursor.execute("SELECT EXISTS(SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME='{}')".format(table_name))
+        return self.cursor.fetchone()[0]
     
     def addTable(self, filename, data):
-        engine = create_engine('postgresql://paraatm_user:paraatm_user@localhost:5432/paraatm')
-        try:
-            data.to_sql(self.filename, engine)
-        except Exception as e:
-            raise(e)
+        if not self.tableExists(filename):
+            engine = create_engine('postgresql://paraatm_user:paraatm_user@localhost:5432/paraatm')
+            data.to_sql(filename, engine)
 
     def getIFFdata(self, filename, kwargs):
         query = "SELECT * FROM \"%s\""%filename


### PR DESCRIPTION
Fix for Issue #4.  Add function to check for existence of table before calling data.to_sql.  This obviates the need to do error handling in data.to_sql.

I suggest further review of checkForTable, as it's not 100% clear what this is doing and whether it is needed.